### PR TITLE
Cache location

### DIFF
--- a/lib/code_cache.rb
+++ b/lib/code_cache.rb
@@ -11,11 +11,11 @@ module CodeCache
     end
   end
   
-  def self.repo(url)
+  def self.repo(url, options = {})
     if self.identify(url) == :git
-      Repo::Git.new(url)
+      Repo::Git.new(url, options)
     else
-      Repo::SVN.new(url)
+      Repo::SVN.new(url, options)
     end
   end
 

--- a/lib/code_cache/repo.rb
+++ b/lib/code_cache/repo.rb
@@ -1,4 +1,6 @@
 require 'fileutils'
+require 'rbconfig'
+require 'tmpdir'
 
 module CodeCache
 
@@ -7,7 +9,8 @@ module CodeCache
     attr_accessor :url, :cache
     
     def initialize(url, options = {})
-      @cache = options[:cache] || '/tmp/code_cache'
+      cache_dir = Dir.tmpdir() if RbConfig::CONFIG['host_os'].include? "ming" 
+      @cache = options[:cache] || cache_dir || '/tmp/code_cache'
       @url = url
       
       check_repo(url)


### PR DESCRIPTION
1. We should now be able to pass cache location when creating object like 
`CodeCache.repo( repo_url, cache_location_hash)`
This will override default storage location.

2. If Cache location is not passed as parameter, depending on platform type (Windows or Linux) cache location is set.