### PR TITLE
Support feature to checkout branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/spec/tmp/
 
 ## Specific to RubyMotion:
 .dat*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,34 @@
 PATH
   remote: .
   specs:
-    code_cache (0.2.0)
+    code_cache (0.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    mixlib-shellout (2.2.7)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   code_cache!
+  mixlib-shellout (~> 2.2.7)
   rspec (~> 3.3)
+
+BUNDLED WITH
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Version control checkout abstraction and cache.
 
     repo =  CodeCache.repo( repo_url )
     begin
-      repo.checkout( :head, 'path/to/checkout' )
+      repo.checkout( :head, 'path/to/checkout' )  # checkout master
+      repo.checkout( :head, 'path/to/checkout', 'branch_name' )  # checkout specific branch
     rescue => e
       puts "Checkout failed"
     end

--- a/code_cache.gemspec
+++ b/code_cache.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'code_cache'
-  s.version     = '0.2.0'
+  s.version     = '0.2.1'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.licenses    = ['MIT']
   s.summary     = "Abstracts & caches svn & git operations"
@@ -10,4 +10,5 @@ Gem::Specification.new do |s|
   s.files       = ["lib/code_cache.rb","lib/code_cache/repo.rb","lib/code_cache/repo/git.rb","lib/code_cache/repo/svn.rb","README.md"]
   s.homepage    = 'https://github.com/bbc/code_cache'
   s.add_development_dependency 'rspec', '~> 3.3'
+  s.add_development_dependency 'mixlib-shellout', '~> 2.2.7'
 end

--- a/lib/code_cache/repo.rb
+++ b/lib/code_cache/repo.rb
@@ -5,9 +5,9 @@ require 'tmpdir'
 module CodeCache
 
   class Repo
-    
+
     attr_accessor :url, :cache
-    
+
     def initialize(url, options = {})
       cache_dir = Dir.tmpdir() if RbConfig::CONFIG['host_os'].include? "ming" 
       @cache = options[:cache] || cache_dir || '/tmp/code_cache'
@@ -54,6 +54,9 @@ module CodeCache
   end
   
   class CopyError < StandardError
+  end
+ 
+  class BranchNotFound < StandardError
   end
 
 end

--- a/lib/code_cache/repo/git.rb
+++ b/lib/code_cache/repo/git.rb
@@ -26,7 +26,7 @@ module CodeCache
     def checkout( revision, destination , branch=nil)
       
       raise "Checking out anything other than the head of the default branch not supported" if revision != :head
-      raise "Not checking out, as destination directory has another git repository" if !Dir["#{destination}/.git"].empty?
+      raise "Not checking out, as #{destination} directory has another git repository" if !Dir["#{destination}/.git"].empty?
       
       cache_destination = location_in_cache()
       

--- a/lib/code_cache/repo/git.rb
+++ b/lib/code_cache/repo/git.rb
@@ -26,7 +26,7 @@ module CodeCache
     def checkout( revision, destination , branch=nil)
       
       raise "Checking out anything other than the head of the default branch not supported" if revision != :head
-      raise "Not checking out as destination directory has another git repository" if !Dir["#{destination}/.git"].empty? 
+      raise "Not checking out, as destination directory has another git repository" if !Dir["#{destination}/.git"].empty?
       
       cache_destination = location_in_cache()
       
@@ -69,7 +69,7 @@ module CodeCache
       end
       status = $? == 0
 
-      raise output if output.include? 'Could not find remote branch'
+      raise CodeCache::BranchNotFound if output.include? 'Could not find remote branch'
 
       { :output => output, :status => status }
     end

--- a/spec/git_helper.rb
+++ b/spec/git_helper.rb
@@ -1,3 +1,5 @@
+require 'mixlib/shellout'
+
 module GitHelpers
   def remote_git_repo(name, options = {})
     pwd = `pwd`.strip

--- a/spec/git_helper.rb
+++ b/spec/git_helper.rb
@@ -1,0 +1,69 @@
+module GitHelpers
+  def remote_git_repo(name, options = {})
+    pwd = `pwd`.strip
+    path = File.join("#{pwd}/spec/tmp/git_remotes", name)
+    remote_url = "file://#{path}"
+
+    FileUtils.mkdir_p(path)
+
+    Dir.chdir(path) do
+      git %|init --bare|
+      git %|config core.sharedrepository 1|
+      git %|config receive.denyNonFastforwards true|
+      git %|config receive.denyCurrentBranch ignore|
+    end
+
+    Dir.chdir(git_scratch) do
+      # Create a bogus file
+      File.open('file', 'w') { |f| f.write('hello') }
+
+      git %|init .|
+      git %|add .|
+      git %|commit -am "Initial commit for #{name}..."|
+      git %|remote add origin "#{remote_url}"|
+      git %|push origin master|
+
+      options[:tags].each do |tag|
+        File.open('tag', 'w') { |f| f.write(tag) }
+        git %|add tag|
+        git %|commit -am "Create tag #{tag}"|
+        git %|tag "#{tag}"|
+        git %|push origin "#{tag}"|
+      end if options[:tags]
+
+      options[:branches].each do |branch|
+        
+        git %|checkout -b #{branch} master|
+        File.open('branch', 'w') { |f| f.write(branch) }
+        git %|add branch|
+        git %|commit -am "Create branch #{branch}"|
+        git %|push origin "#{branch}"|
+        git %|checkout master|
+      end if options[:branches]
+    end
+
+    path
+  end
+  
+  def git_scratch
+        path = File.join(File.expand_path("../../tmp", __FILE__), "git", "scratch")
+        FileUtils.mkdir_p(path) unless File.directory?(path)
+        path
+  end
+
+  def git(command)
+     shellout!("git #{command}")
+  end
+
+  def shellout!(command, options = {})
+     cmd = Mixlib::ShellOut.new(command, options)
+     cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
+     cmd.run_command
+     cmd
+  end
+end
+
+RSpec.configure do |config|
+  config.include(GitHelpers)
+end
+

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -75,6 +75,13 @@ describe CodeCache::Repo::Git do
     
     end
 
+    it 'raises exception when branch not found' do
+      cache = CACHE_BASE+rand(999999).to_s
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => cache)
+      destination = "/tmp/checkouts/#{rand(999999)}/code_cache"
+      expect{repo.checkout(:head, destination, 'test1')}.to raise_error(CodeCache::BranchNotFound)
+    end
+
     it 'checks out the same repo twice using the cache' do
 
       cache = CACHE_BASE+rand(999999).to_s

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -1,33 +1,33 @@
 require 'code_cache/repo'
 require 'code_cache/repo/git'
-
-GIT_URL = 'git@github.com:bbc/code_cache.git'
-HTTPS_URL = 'https://github.com/bbc/code_cache.git'
+require 'git_helper'
 
 CACHE_BASE = '/tmp/code_cache_tests_'
 
 describe CodeCache::Repo::Git do
-  
+
+  let(:bare_repo){remote_git_repo('fake', {:branches => ['test']})}
+
   describe '.new' do
-    
+   
     it 'creates a repo object' do
-      repo = CodeCache::Repo::Git.new( GIT_URL )
+      repo = CodeCache::Repo::Git.new( bare_repo )
       expect(repo).to be_a CodeCache::Repo::Git
     end  
     
     it "throws an exception if the repo url can't be hit" do
-      expect{CodeCache::Repo::Git.new( GIT_URL + 'bad' )}.to raise_error(CodeCache::BadRepo)
+      expect{CodeCache::Repo::Git.new( bare_repo + 'bad' )}.to raise_error(CodeCache::BadRepo)
     end
       
   end
   
   describe '#clone_repo_to_cache' do
-    
-    it 'clones a repository to the cache without a checkout' do
+  let(:repo) { remote_git_repo('fake') }   
 
+ 
+    it 'clones a repository to the cache without a checkout' do
       cache = CACHE_BASE+rand(999999).to_s
-      
-      repo = CodeCache::Repo::Git.new( GIT_URL, :cache => cache )
+      repo = CodeCache::Repo::Git.new( bare_repo,  :cache => cache )
       
       cache_destination = repo.location_in_cache()
       repo.clone_bare_repo_to_cache(cache_destination)
@@ -44,7 +44,7 @@ describe CodeCache::Repo::Git do
       
       cache = CACHE_BASE+rand(999999).to_s
       
-      repo = CodeCache::Repo::Git.new( GIT_URL, :cache => cache )
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => cache )
       
       destination = "/tmp/checkouts/#{rand(999999)}/code_cache"
       
@@ -52,21 +52,33 @@ describe CodeCache::Repo::Git do
       
       expect( result ).to eq true
       
-      cached_clone = cache + '/git/github.com/bbc/code_cache/'
+      cached_clone = repo.location_in_cache()
       
       expect( Dir.exist?(cached_clone) ).to eq true
       expect( Dir.exist?(cached_clone + '/refs') ).to be true
       
       expect( Dir.exist?(destination) ).to eq true
       expect( Dir.exist?(destination+'/.git')).to eq true
-      expect( File.exist?(destination + '/README.md') ).to be true
-      
     end
     
+    it 'checks out the specific branch' do
+      cache = CACHE_BASE+rand(999999).to_s
+
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => cache)
+      
+      destination = "/tmp/checkouts/#{rand(999999)}/code_cache"
+      
+      result = repo.checkout( :head, destination, 'test' )
+      expect( Dir.exist?(destination) ).to eq true 
+      branch = `cd #{destination} && git branch`.strip.gsub!("* ","")
+      expect(branch).to eq 'test'
+    
+    end
+
     it 'checks out the same repo twice using the cache' do
 
       cache = CACHE_BASE+rand(999999).to_s
-      repo = CodeCache::Repo::Git.new( GIT_URL, :cache => cache )
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => cache )
       
       destination_1 = "/tmp/checkouts/#{rand(999999)}/code_cache"
       destination_2 = destination_1 + '-second'
@@ -95,7 +107,7 @@ describe CodeCache::Repo::Git do
       cache = CACHE_BASE+rand(999999).to_s
       `rm -rf #{cache}`
       
-      repo = CodeCache::Repo::Git.new( GIT_URL, :cache => cache )
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => cache )
       
       repo.create_cache(:head)
       
@@ -106,16 +118,11 @@ describe CodeCache::Repo::Git do
     
   describe '#location_in_cache' do
     
-    it 'calculates the location of a checkout in the cache from an ssh url' do
-      repo = CodeCache::Repo::Git.new( GIT_URL, :cache => '/tmp/cache' )
-      expect(repo.location_in_cache(:head)).to eq '/tmp/cache/git/github.com/bbc/code_cache/head'
+    it 'calculates the location of a checkout in the cache from an repo url' do
+      repo = CodeCache::Repo::Git.new( bare_repo, :cache => '/tmp/cache' )
+      expect(repo.location_in_cache(:head)).to eq '/tmp/cache/git/head'
     end
-    
-    it 'calculates the location of a checkout in the cache from an https url' do
-      repo = CodeCache::Repo::Git.new( HTTPS_URL, :cache => '/tmp/cache' )
-      expect(repo.location_in_cache(:head)).to eq '/tmp/cache/git/github.com/bbc/code_cache/head'
-    end
-    
+
   end
   
 end


### PR DESCRIPTION
1. Should be able to checkout branches from github.
2. Tests now uses mock github instead of cloning each time from github
3. Added test to check out specific branch

Fix #9 